### PR TITLE
Changes Dockerfile so that tools are built from the local files.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,11 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install glancecp
-RUN cd /tmp \
-    && git clone https://github.com/wtsi-hgi/openstack-tools.git \
-    && cd openstack-tools \
+RUN mkdir /tmp/openstack-tools
+ADD . /tmp/openstack-tools
+RUN cd /tmp/openstack-tools \
     && python3 setup.py install
+RUN rm -rf /tmp/openstack-tools
 
 # Set workdir and entrypoint
 WORKDIR /tmp


### PR DESCRIPTION
Is there a good reason to have the Dockerfile install the tools from the GitHub repository, opposed to installing from the local files? The former prevents the use of the Dockerfile during development and breaks quay.io's assumption that it can build images for each branch.